### PR TITLE
feat(admin-bundle): Faros NG 3.0, remove deprecated `security.enable_authenticator_manager` in SF 6.2

### DIFF
--- a/faros-ng/admin-bundle/3.0/config/packages/faros_admin.yaml
+++ b/faros-ng/admin-bundle/3.0/config/packages/faros_admin.yaml
@@ -1,0 +1,8 @@
+faros_admin:
+    firewalls: ["main"]
+
+twig:
+    globals:
+        project:
+            name: Faros
+            logo: /bundles/farosadmin/themes/avant/img/logo-faros.png

--- a/faros-ng/admin-bundle/3.0/config/packages/roles.yaml
+++ b/faros-ng/admin-bundle/3.0/config/packages/roles.yaml
@@ -1,0 +1,15 @@
+security:
+    role_hierarchy:
+        ROLE_SUPER_ADMIN:
+            - ROLE_ADMIN
+            - ROLE_ALLOWED_TO_SWITCH
+        ROLE_ADMIN:
+            - ROLE_ADMIN_LOGIN
+            - ROLE_ADMIN_USER
+            - ROLE_ADMIN_GROUP
+            - ROLE_ADMIN_ACTION
+
+imports:
+    - { resource: "@FarosAdminBundle/Resources/config/role/core.yml" }
+    - { resource: "@FarosAdminBundle/Resources/config/role/elfinder.yml" }
+    - { resource: "@FarosAdminBundle/Resources/config/role/seo.yml" }

--- a/faros-ng/admin-bundle/3.0/config/packages/security.yaml
+++ b/faros-ng/admin-bundle/3.0/config/packages/security.yaml
@@ -1,0 +1,49 @@
+imports:
+    - { resource: roles.yaml }
+
+security:
+    # hide_user_not_found: false # true by default, if set to false will show "locked" or "not found" user error
+
+    # https://symfony.com/doc/current/security.html#registering-the-user-hashing-passwords
+    password_hashers:
+        Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: "auto"
+
+    # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
+    providers:
+        # users_in_memory: { memory: null }
+        main:
+            entity:
+                class: App\Entity\User
+                property: email
+
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js|bundles|assets|build)/
+            security: false
+        main:
+            provider: main
+            user_checker: "faros_user.user_checker"
+            pattern: ^/
+            form_login:
+                username_parameter: email
+                password_parameter: password
+                login_path: admin_login
+                check_path: admin_login
+
+            # activate different ways to authenticate
+            # https://symfony.com/doc/current/security.html#the-firewall
+
+            # https://symfony.com/doc/current/security/impersonating_user.html
+            switch_user: true
+
+            # https://symfony.com/doc/current/security.html#limiting-login-attempts
+            login_throttling:
+                max_attempts: 10
+                interval: "3 minutes"
+
+    access_control:
+        - { path: ^/translations, roles: PUBLIC_ACCESS }
+        - { path: ^/login, roles: PUBLIC_ACCESS }
+        - { path: ^/logout, roles: PUBLIC_ACCESS }
+        - { path: ^/forgot-password, roles: PUBLIC_ACCESS }
+        - { path: ^/, role: ROLE_ADMIN }

--- a/faros-ng/admin-bundle/3.0/config/routes/faros_admin.yaml
+++ b/faros-ng/admin-bundle/3.0/config/routes/faros_admin.yaml
@@ -1,0 +1,19 @@
+faros_admin_admin:
+    resource: "@FarosAdminBundle/Resources/config/routing/admin.yml"
+
+faros_admin_core:
+    resource: "@FarosAdminBundle/Resources/config/routing/core.yml"
+
+faros_admin_export:
+    resource: "@FarosAdminBundle/Resources/config/routing/export.yml"
+
+faros_admin_elfinder:
+    resource: "@FarosAdminBundle/Resources/config/routing/elfinder.yml"
+# faros_admin_seo:
+#     resource: "@FarosAdminBundle/Resources/config/routing/seo.yml"
+
+# faros_admin_event_log:
+#     resource: "@FarosAdminBundle/Resources/config/routing/event_log.yml"
+
+# faros_admin_scheduled_task:
+#     resource: "@FarosAdminBundle/Resources/config/routing/scheduled_task.yml"

--- a/faros-ng/admin-bundle/3.0/fixtures/faros.yml
+++ b/faros-ng/admin-bundle/3.0/fixtures/faros.yml
@@ -1,0 +1,44 @@
+App\Entity\User:
+    super-admin:
+        enabled: "true"
+        firstname: Admin
+        lastname: Admin
+        username: admin.project
+        password: changeme
+        email: john.doe@example.com
+        userRoles: ["ROLE_SUPER_ADMIN"]
+
+App\Entity\Group:
+    group_admin:
+        roles: ["ROLE_ADMIN"]
+        users: ["@super-admin"]
+        name: Administrateurs
+
+App\Entity\Parameter:
+    emails.password_token_interval:
+        name: emails.password_token_interval
+        value: 48
+        description: "Temps de validité (en heures) du lien de remise à zéro du mot de passe utilisateur."
+        type: Symfony\Component\Form\Extension\Core\Type\IntegerType
+    emails.noreplyemail:
+        name: emails.noreplyemail
+        value: noreply@lephare.com
+        description: "Adresse d'expédition des emails envoyés par l'application"
+        type: Symfony\Component\Form\Extension\Core\Type\TextType
+    emails.noreplyname:
+        name: emails.noreplyname
+        value: No Reply
+        description: "Nom d'expédition des emails envoyés par l'application"
+        type: Symfony\Component\Form\Extension\Core\Type\TextType
+
+App\Entity\Export:
+    user_top_connection:
+        name: user_top_connection
+        title: Top connexion utilisateurs
+        description: |
+            Contient la liste des 100 utilisateurs qui se connectent le plus souvent à l'application
+        sql: |
+            SELECT u.email, COUNT(DISTINCT a.id)
+            FROM faros_user_action a
+            INNER JOIN _user u ON (a.user_id = u.id)
+            WHERE a.name = 'admin.login'

--- a/faros-ng/admin-bundle/3.0/manifest.json
+++ b/faros-ng/admin-bundle/3.0/manifest.json
@@ -1,0 +1,10 @@
+{
+    "bundles": {
+        "Faros\\Bundle\\AdminBundle\\FarosAdminBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "fixtures/": "fixtures/",
+        "config/": "%CONFIG_DIR%/",
+        "src/": "%SRC_DIR%/"
+    }
+}


### PR DESCRIPTION
Changelog Symfony 6.2 : [feature #47890 [SecurityBundle] Deprecate the `enable_authenticator_manager` option (chalasr)](https://github.com/symfony/symfony/blob/6.4/CHANGELOG-6.2.md?plain=1#L474)