### PR TITLE
feat(deploy-pack): add blank `lephare_packagist_com_token` to Ansible vault

### DIFF
--- a/faros-ng/deploy-pack/1.5/ansible/_variables.yml
+++ b/faros-ng/deploy-pack/1.5/ansible/_variables.yml
@@ -23,6 +23,7 @@ lephare_composer_options: "--no-dev --optimize-autoloader --apcu-autoloader --no
 lephare_crontab_path: "{{ ansistrano_release_path.stdout }}/.crontab"
 lephare_crontab_install: true
 lephare_install_adminer: false
+lephare_packagist_com_token: "{{ vault_lephare_packagist_com_token }}"
 
 # (db-pull) Database settings
 db_pull_local_database_host: <local_database_host>

--- a/faros-ng/deploy-pack/1.5/ansible/preprod/group_vars/app/vault
+++ b/faros-ng/deploy-pack/1.5/ansible/preprod/group_vars/app/vault
@@ -1,1 +1,2 @@
 vault_database_password: <remote_database_password>
+vault_lephare_packagist_com_token: <lephare_packagist_com_token>


### PR DESCRIPTION
When the `lephare_packagist_com_token` Ansible variable isn't set (in the Vault or elsewhere), [the `private_registry` Ansible job that installs a Packagist.com token is skipped](https://github.com/le-phare/ansible-deploy/blob/9b8e6d87e1ac9e21e9541b8a8280a2ab5da6c5a6/config/steps/composer/private_registry.yml#L13), triggering Composer's `AUTHENTICATION FAILURE` errors.

Setting this variable in the vault encourages the developer to configure it and avoid Composer errors.