### PR TITLE
chore: comment default host value

### DIFF
--- a/faros-ng/deploy-pack/1.4/ansible/preprod/hosts
+++ b/faros-ng/deploy-pack/1.4/ansible/preprod/hosts
@@ -1,2 +1,2 @@
 [app]
-<preprod_domain>
+#<preprod_domain>

--- a/faros-ng/deploy-pack/1.4/ansible/prod/hosts
+++ b/faros-ng/deploy-pack/1.4/ansible/prod/hosts
@@ -1,2 +1,2 @@
 [app]
-<production_domain>
+#<production_domain>


### PR DESCRIPTION
By executing a playbook with default recipes values, we should have an error thrown by Ansible like "no host matching inventory" instead of using "<production_domain>"

https://lephare.slack.com/archives/C015VCJUK4G/p1705076341178659?thread_ts=1705074704.019719&cid=C015VCJUK4G