### PR TITLE
chore(docker-pack): update recipe

### DIFF
--- a/faros-ng/docker-pack/2.2/docker-compose.yml
+++ b/faros-ng/docker-pack/2.2/docker-compose.yml
@@ -1,20 +1,24 @@
 services:
     php:
-        image: lephare/php:8.2
+        image: lephare/php:8.3
         volumes:
             - ./:/var/www/symfony
+            - ${COMPOSER_HOME:-~/.composer}:/tmp/composer
         environment:
+            COMPOSER_HOME: /tmp/composer
+            DOCKER_HOST_SUFFIX: ${DOCKER_HOST_SUFFIX:-local}
             SYMFONY_DEPRECATIONS_HELPER: "max[direct]=0&verbose=1"
         networks:
             - default
             - private
+
     web:
         image: lephare/apache:2.4
         networks:
             - default
             - public
-        volumes:
-            - ./:/var/www/symfony
+        volumes_from:
+            - php:ro
         labels:
             caddy: 'project.${DOCKER_HOST_SUFFIX:-local}'
             caddy.tls: internal

--- a/faros-ng/docker-pack/2.2/public/.htaccess
+++ b/faros-ng/docker-pack/2.2/public/.htaccess
@@ -18,10 +18,6 @@ DirectoryIndex index.php
    ExpiresByType application/x-font-woff "access plus 10 years"
 </IfModule>
 
-<filesMatch ".(svg)$">
-AddOutputFilterByType DEFLATE image/svg+xml
-</filesMatch>
-
 <filesMatch ".(svg|woff2|woff)$">
 ExpiresDefault "access plus 10 years"
 FileETag None


### PR DESCRIPTION
- update PHP to 8.3
- mount COMPOSER_HOME
- SVG files are now compressed using Brotli by `lephare/apache` Docker image (https://github.com/le-phare/docker-apache/pull/5/commits/2e9ffbae983b030b4fb6e8eb4a0fd075174da9b0)

Fixes #40
Fixes #41