### PR TITLE
fix(docker-pack): .spells: add to manifest, allow killing long Docker processes

### DIFF
--- a/faros-ng/docker-pack/2.3/.env.dev
+++ b/faros-ng/docker-pack/2.3/.env.dev
@@ -1,3 +1,3 @@
 SENTRY_DSN=
 MAILER_DSN=smtp://maildev:25
-DATABASE_URL="postgres://postgres:root@pgsql_15:5432/project?serverVersion=15&charset=utf8"
+DATABASE_URL="postgres://postgres:root@pgsql_16:5432/project?serverVersion=16&charset=utf8"

--- a/faros-ng/docker-pack/2.3/.env.dev
+++ b/faros-ng/docker-pack/2.3/.env.dev
@@ -1,0 +1,3 @@
+SENTRY_DSN=
+MAILER_DSN=smtp://maildev:25
+DATABASE_URL="postgres://postgres:root@pgsql_15:5432/project?serverVersion=15&charset=utf8"

--- a/faros-ng/docker-pack/2.3/.spells
+++ b/faros-ng/docker-pack/2.3/.spells
@@ -12,9 +12,9 @@ _docker_exec()
 _docker_run()
 {
     if [ "$(uname -s)" != "Darwin" ]; then
-        docker run --rm -it -u "$(id -u):$(id -g)" "$@"
+        docker run --init --rm -it -u "$(id -u):$(id -g)" "$@"
     else
-        docker run --rm -it "$@"
+        docker run --init --rm -it "$@"
     fi
 }
 

--- a/faros-ng/docker-pack/2.3/docker-compose.yml
+++ b/faros-ng/docker-pack/2.3/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+    php:
+        image: lephare/php:8.3
+        volumes:
+            - ./:/var/www/symfony
+            - ${COMPOSER_HOME:-~/.composer}:/tmp/composer
+        environment:
+            COMPOSER_HOME: /tmp/composer
+            DOCKER_HOST_SUFFIX: ${DOCKER_HOST_SUFFIX:-local}
+            SYMFONY_DEPRECATIONS_HELPER: "max[direct]=0&verbose=1"
+        networks:
+            - default
+            - private
+
+    web:
+        image: lephare/apache:2.4
+        networks:
+            - default
+            - public
+        volumes_from:
+            - php:ro
+        labels:
+            caddy: 'project.${DOCKER_HOST_SUFFIX:-local}'
+            caddy.tls: internal
+            caddy.reverse_proxy: '{{ upstreams }}'
+        environment:
+            DOCUMENT_ROOT: /var/www/symfony/public
+
+networks:
+    private:
+        external: true
+        name: dev_private
+    public:
+        external: true
+        name: dev_public

--- a/faros-ng/docker-pack/2.3/manifest.json
+++ b/faros-ng/docker-pack/2.3/manifest.json
@@ -1,0 +1,11 @@
+{
+    "copy-from-recipe": {
+        ".env.dev": ".env.dev",
+        ".spells": ".spells",
+        "docker-compose.yml": "docker-compose.yml",
+        "public/": "%PUBLIC_DIR%/"
+    },
+    "gitignore": [
+        "docker-compose.override.yml"
+    ]
+}

--- a/faros-ng/docker-pack/2.3/post-install.txt
+++ b/faros-ng/docker-pack/2.3/post-install.txt
@@ -1,0 +1,11 @@
+<bg=blue;fg=white>                      </>
+<bg=blue;fg=white> Docker configuration </>
+<bg=blue;fg=white>                      </>
+
+  * <fg=blue>Update</> the <comment>VIRTUAL_HOST</> environment variable in the file <comment>docker-compose.yml</>
+
+  * <fg=blue>Update</> the database name in the file <comment>.env.dev</>
+
+  * <fg=blue>Run</> your application:
+    1. Change to the project directory
+    2. Execute the <comment>docker-compose up -d</> command

--- a/faros-ng/docker-pack/2.3/public/.htaccess
+++ b/faros-ng/docker-pack/2.3/public/.htaccess
@@ -1,0 +1,74 @@
+# Use the front controller as index file. It serves as a fallback solution when
+# every other rewrite/redirect fails (e.g. in an aliased environment without
+# mod_rewrite). Additionally, this reduces the matching process for the
+# start page (path "/") because otherwise Apache will apply the rewriting rules
+# to each configured DirectoryIndex file (e.g. index.php, index.html, index.pl).
+DirectoryIndex index.php
+
+<IfModule mod_expires.c>
+   ExpiresActive On
+   ExpiresByType image/gif "access plus 10 years"
+   ExpiresByType image/jpeg "access plus 10 years"
+   ExpiresByType image/png "access plus 10 years"
+   ExpiresByType text/css "access plus 10 years"
+   ExpiresByType text/javascript "access plus 10 years"
+   ExpiresByType application/javascript "access plus 10 years"
+   ExpiresByType application/x-unknown-content-type "access plus 10 years"
+   ExpiresByType application/x-javascript "access plus 10 years"
+   ExpiresByType application/x-font-woff "access plus 10 years"
+</IfModule>
+
+<filesMatch ".(svg|woff2|woff)$">
+ExpiresDefault "access plus 10 years"
+FileETag None
+</filesMatch>
+
+<filesMatch ".(js|css)$">
+FileETag None
+</filesMatch>
+
+<filesMatch "^(favicon|apple-touch-icon|android-chrome|mstile)">
+FileETag None
+</filesMatch>
+
+# ----------------------------------------------------------------------
+# Allow loading of external fonts
+# ----------------------------------------------------------------------
+<FilesMatch "\.(ttf|otf|eot|woff|woff2)$">
+    Header set Access-Control-Allow-Origin "*"
+</FilesMatch>
+
+# Security Headers
+Header set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+Header set X-Frame-Options "SAMEORIGIN"
+Header set X-XSS-Protection "1; mode=block"
+Header set X-Content-Type-Options "nosniff"
+Header set Referrer-Policy "strict-origin-when-cross-origin"
+
+# By default, Apache does not evaluate symbolic links if you did not enable this
+# feature in your server configuration. Uncomment the following line if you
+# install assets as symlinks or if you experience problems related to symlinks
+# when compiling LESS/Sass/CoffeScript assets.
+Options FollowSymlinks
+
+# Authorization settings
+
+
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+
+    # Sets the HTTP_AUTHORIZATION header removed by Apache
+    RewriteCond %{HTTP:Authorization} .
+    RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
+    RewriteCond %{ENV:REDIRECT_STATUS} ^$
+    RewriteRule ^index\.php(?:/(.*)|$) /$1 [R=301,L]
+
+    # If the requested filename exists, simply serve it.
+    # We only want to let Apache serve files and not directories.
+    RewriteCond %{REQUEST_FILENAME} -f
+    RewriteRule ^ - [L]
+
+    # Rewrite all other queries to the front controller.
+    RewriteRule ^ /index.php [L]
+</IfModule>


### PR DESCRIPTION
Needed for some processes like Symfony Messenger consume for example.