### PR TITLE
feat(docker-pack): allow killing PHP commands

### DIFF
--- a/faros-ng/docker-pack/2.3/docker-compose.yml
+++ b/faros-ng/docker-pack/2.3/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
     php:
         image: lephare/php:8.3
+        init: true
         volumes:
             - ./:/var/www/symfony
             - ${COMPOSER_HOME:-~/.composer}:/tmp/composer


### PR DESCRIPTION
Without `init: true`, Ctrl+C does nothing on PHP CLI commands (`sf make:foobar` for example).
See https://docs.docker.com/reference/compose-file/services/#init